### PR TITLE
Copy "seen" before handing it to resolve_schema_references to prevent…

### DIFF
--- a/fastapi_mcp/openapi/utils.py
+++ b/fastapi_mcp/openapi/utils.py
@@ -57,11 +57,11 @@ def resolve_schema_references(
     # Recursively resolve references in all dictionary values
     for key, value in schema_part.items():
         if isinstance(value, dict):
-            schema_part[key] = resolve_schema_references(value, reference_schema, seen)
+            schema_part[key] = resolve_schema_references(value, reference_schema, seen.copy())
         elif isinstance(value, list):
             # Only process list items that are dictionaries since only they can contain refs
             schema_part[key] = [
-                resolve_schema_references(item, reference_schema, seen) if isinstance(item, dict) else item
+                resolve_schema_references(item, reference_schema, seen.copy()) if isinstance(item, dict) else item
                 for item in value
             ]
 


### PR DESCRIPTION
Hi Jonvet,

thanks for solving this problem! I ran into it as well and found your PR (https://github.com/tadata-org/fastapi_mcp/pull/156). When I used your proposed fix though I found that there is one specific case where the current version of the code makes a mistake. It happens when a model has two properties **on the same level** that are of the self-referencing type. When this happens the second (and following...) properties are treated differently than the first one although they are at the same level.

Adding a copy to the seen set before handing it to new passes of resolve_schema_references makes sure that this does not happen as the first instance is not updating the parent set.

An example where this would happen: 

```

class Player(BaseModel):
    name: str
    number_of_games: int
    teacher: Optional[Player] = None  # self-referencing

class Game(BaseModel):
    playerA: Player
    playerB: Player


```

In this case playerB will be represented by the $ref while playerA is allowed one level of recursion.